### PR TITLE
Set up React UI with AG Grid live positions table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+build/
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.env

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-console.log('Happy developing ✨')

--- a/package.json
+++ b/package.json
@@ -1,10 +1,22 @@
 {
-  "name": "WorkbenchGUI",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "name": "workbench-ui",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "ag-grid-community": "^31.3.1",
+    "ag-grid-react": "^31.3.1",
+    "bootswatch": "^5.3.3",
+    "react": "^18.2.0",
+    "react-bootstrap": "^2.9.1",
+    "react-dom": "^18.2.0"
   },
-  "private": true
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "react-scripts": "5.0.1"
+  }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Workbench UI</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import Container from 'react-bootstrap/Container';
+import Navbar from 'react-bootstrap/Navbar';
+
+import DataTable from './components/DataTable';
+
+const App = () => {
+  return (
+    <div className="d-flex flex-column min-vh-100">
+      <Navbar bg="dark" variant="dark" className="shadow-sm">
+        <Container>
+          <Navbar.Brand href="#home" className="fw-semibold text-uppercase">
+            Live Position
+          </Navbar.Brand>
+        </Container>
+      </Navbar>
+
+      <main className="flex-fill d-flex align-items-center justify-content-center py-4">
+        <Container>
+          <DataTable />
+        </Container>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -1,0 +1,28 @@
+import React, { useMemo, useState } from 'react';
+import Card from 'react-bootstrap/Card';
+import { AgGridReact } from 'ag-grid-react';
+
+import { getLivePositionColumnDefs, getLivePositionRowData } from '../data/livePositionData';
+
+const DataTable = () => {
+  const columnDefs = useMemo(() => getLivePositionColumnDefs(), []);
+  const [rowData] = useState(() => getLivePositionRowData());
+
+  return (
+    <Card bg="dark" text="light" className="shadow-lg">
+      <Card.Header className="fs-5">Current Positions</Card.Header>
+      <Card.Body>
+        <div className="ag-theme-alpine-dark" style={{ height: 400, width: '100%' }}>
+          <AgGridReact
+            columnDefs={columnDefs}
+            rowData={rowData}
+            domLayout="autoHeight"
+            animateRows
+          />
+        </div>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default DataTable;

--- a/src/data/livePositionData.js
+++ b/src/data/livePositionData.js
@@ -1,0 +1,67 @@
+const positions = [
+  {
+    symbol: 'AAPL',
+    product: 'Equity',
+    quantity: 120,
+    price: 182.34,
+    marketValue: 21880.8,
+    pnl: 1540.2,
+  },
+  {
+    symbol: 'TSLA',
+    product: 'Equity',
+    quantity: 45,
+    price: 245.76,
+    marketValue: 11059.2,
+    pnl: -320.5,
+  },
+  {
+    symbol: 'BTC-USD',
+    product: 'Crypto',
+    quantity: 1.2,
+    price: 29450.5,
+    marketValue: 35340.6,
+    pnl: 4210.3,
+  },
+  {
+    symbol: 'ESU23',
+    product: 'Futures',
+    quantity: 3,
+    price: 4538.5,
+    marketValue: 13615.5,
+    pnl: 275.0,
+  },
+];
+
+export const getLivePositionRowData = () => positions;
+
+export const getLivePositionColumnDefs = () => [
+  { headerName: 'Symbol', field: 'symbol', sortable: true, filter: true, flex: 1 },
+  { headerName: 'Product', field: 'product', sortable: true, filter: true, flex: 1 },
+  { headerName: 'Quantity', field: 'quantity', sortable: true, filter: 'agNumberColumnFilter', flex: 1 },
+  {
+    headerName: 'Price',
+    field: 'price',
+    sortable: true,
+    filter: 'agNumberColumnFilter',
+    flex: 1,
+    valueFormatter: ({ value }) => `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+  },
+  {
+    headerName: 'Market Value',
+    field: 'marketValue',
+    sortable: true,
+    filter: 'agNumberColumnFilter',
+    flex: 1,
+    valueFormatter: ({ value }) => `$${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+  },
+  {
+    headerName: 'P&L',
+    field: 'pnl',
+    sortable: true,
+    filter: 'agNumberColumnFilter',
+    flex: 1,
+    cellClass: params => (params.value >= 0 ? 'text-success' : 'text-danger'),
+    valueFormatter: ({ value }) => `${value >= 0 ? '+' : '-'}$${Math.abs(value).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+  },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,11 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #121212;
+  color: #f8f9fa;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+#root {
+  min-height: 100vh;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import 'bootswatch/dist/darkly/bootstrap.min.css';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine-dark.css';
+import './index.css';
+
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- scaffold a React application with React Scripts, Bootswatch dark theme, and shared styling
- implement a Live Position navigation header and central AG Grid table layout component
- add a dedicated data handler that supplies formatted sample live position data to the grid

## Testing
- npm install *(fails: 403 Forbidden fetching ag-grid-community from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6ee8744083238514794786a093a4